### PR TITLE
Add sharing service with Instagram Stories support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <queries>
+        <package android:name="com.instagram.android" />
+        <intent>
+            <action android:name="com.instagram.share.ADD_TO_STORY" />
+            <data android:mimeType="image/*" />
+        </intent>
+    </queries>
     <application
         android:label="Goth Mood Tracker"
         android:name="${applicationName}"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'share_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -214,32 +215,58 @@ class _HistoryScreenState extends State<HistoryScreen> {
               final e = _entries[i];
               final ts = DateTime.tryParse(e['ts'] as String? ?? '')?.toLocal();
               final note = (e['note'] as String?)?.trim();
-              return Container(
-                decoration: BoxDecoration(
-                  color: const Color(0xFF1A1A1F),
-                  borderRadius: BorderRadius.circular(18),
-                ),
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(e['mood'] ?? '', style: theme.textTheme.titleMedium),
-                    if (ts != null)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 4),
-                        child: Text(
-                          '${ts.year.toString().padLeft(4, '0')}-${ts.month.toString().padLeft(2, '0')}-${ts.day.toString().padLeft(2, '0')} '
-                          '${ts.hour.toString().padLeft(2, '0')}:${ts.minute.toString().padLeft(2, '0')}',
-                          style: theme.textTheme.bodySmall?.copyWith(color: Colors.white70),
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Shareable(
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF1A1A1F),
+                        borderRadius: BorderRadius.circular(18),
+                      ),
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(e['mood'] ?? '', style: theme.textTheme.titleMedium),
+                          if (ts != null)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 4),
+                              child: Text(
+                                '${ts.year.toString().padLeft(4, '0')}-${ts.month.toString().padLeft(2, '0')}-${ts.day.toString().padLeft(2, '0')} '
+                                '${ts.hour.toString().padLeft(2, '0')}:${ts.minute.toString().padLeft(2, '0')}',
+                                style: theme.textTheme.bodySmall?.copyWith(color: Colors.white70),
+                              ),
+                            ),
+                          if (note != null && note.isNotEmpty)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 8),
+                              child: Text(note, style: theme.textTheme.bodyMedium?.copyWith(color: Colors.white70)),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      IconButton(
+                        tooltip: 'Share',
+                        icon: const Icon(Icons.ios_share),
+                        onPressed: () => shareGeneric(text: 'My Goth Mood streak 👇'),
+                      ),
+                      const SizedBox(width: 8),
+                      IconButton(
+                        tooltip: 'Share to Instagram Stories',
+                        icon: const Icon(Icons.camera_alt_outlined),
+                        onPressed: () => shareToInstagramStories(
+                          attributionUrl: 'https://pixelpanic.shop',
                         ),
                       ),
-                    if (note != null && note.isNotEmpty)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 8),
-                        child: Text(note, style: theme.textTheme.bodyMedium?.copyWith(color: Colors.white70)),
-                      ),
-                  ],
-                ),
+                    ],
+                  ),
+                ],
               );
             },
           ),

--- a/lib/share_service.dart
+++ b/lib/share_service.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:screenshot/screenshot.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:instagram_share_plus/instagram_share_plus.dart';
+
+final screenshotController = ScreenshotController();
+
+class Shareable extends StatelessWidget {
+  final Widget child;
+  const Shareable({super.key, required this.child});
+  @override
+  Widget build(BuildContext context) =>
+      Screenshot(controller: screenshotController, child: child);
+}
+
+Future<File?> _captureShareImage() async {
+  final bytes = await screenshotController.capture();
+  if (bytes == null) return null;
+  final dir = await getTemporaryDirectory();
+  final file = File('${dir.path}/goth_mood_share.png');
+  await file.writeAsBytes(bytes);
+  return file;
+}
+
+Future<void> shareGeneric({String? text}) async {
+  final file = await _captureShareImage();
+  if (file == null) return;
+  await Share.shareXFiles([XFile(file.path)], text: text ?? 'Goth Mood Tracker');
+}
+
+Future<void> shareToInstagramStories({String? attributionUrl}) async {
+  final file = await _captureShareImage();
+  if (file == null) return;
+  final installed = await InstagramSharePlus.isInstagramInstalled();
+  if (!installed) {
+    await shareGeneric(text: 'Goth Mood Tracker');
+    return;
+  }
+  await InstagramSharePlus.shareToStories(
+    imagePath: file.path,
+    backgroundTopColor: '#000000',
+    backgroundBottomColor: '#000000',
+    attributionURL: attributionUrl ?? 'https://pixelpanic.shop',
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,10 @@ dependencies:
     sdk: flutter
   package_info_plus: ^9.0.0
   shared_preferences: ^2.2.3
+  share_plus: ^10.0.2
+  screenshot: ^2.5.0
+  path_provider: ^2.1.4
+  instagram_share_plus: ^1.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add share_plus, screenshot, path_provider, and instagram_share_plus dependencies
- enable Instagram Stories sharing in Android manifest
- implement screenshot-based sharing service with generic and Instagram Stories options
- wire sharing buttons into mood history cards

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c76f88b998832b9f985faccc669076