### PR TITLE
feat: integrate AdMob ads

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   cupertino_icons: ^1.0.6
   share_plus: ^10.0.2
   path_provider: ^2.1.4
-  google_mobile_ads: ^6.0.0
+  google_mobile_ads: ^5.1.0
   package_info_plus: ^8.0.2
   shared_preferences: ^2.3.3
 


### PR DESCRIPTION
## Summary
- add the google_mobile_ads dependency and initialize MobileAds at startup with release/test unit IDs
- track mood log counts in SharedPreferences so an interstitial can show after five logs when returning to History
- render a banner ad at the bottom of the History tab and clean up ad resources appropriately

## Testing
- Unable to run `flutter pub get` (flutter tool not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c907592c50832ba73b8fca94071242